### PR TITLE
すべてのファイルに電子署名を付与する仕様に変更

### DIFF
--- a/cmd/5_split.go
+++ b/cmd/5_split.go
@@ -246,6 +246,5 @@ func split(file string, version string) error {
 	if err != nil {
 		return err
 	}
-	err = AddSing(dstDir+"/info.json", privateKeyBytes)
 	return err
 }

--- a/cmd/6_add_gtfs_id_info.go
+++ b/cmd/6_add_gtfs_id_info.go
@@ -66,7 +66,6 @@ func main() {
 			}
 
 			json.DumpToFile(versionInfo, "./v0.0.0/"+dir.Name()+"/info.json")
-			AddSing("./v0.0.0/"+dir.Name()+"/info.json", privateKeyBytes)
 		}
 	}
 }

--- a/cmd/7_add_datalist.go
+++ b/cmd/7_add_datalist.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"time"
 	"net/http"
 	"strings"
 
-	. "github.com/takoyaki-3/butter/cmd/helper"
 	json "github.com/takoyaki-3/go-json"
 )
 
@@ -53,12 +50,6 @@ type Data []struct {
 }
 
 func main() {
-	// RSA秘密鍵を読み込む
-	privateKeyBytes, err := ioutil.ReadFile("key.pem")
-	if err != nil {
-		log.Fatalln(err)
-	}
-
 	//
 	data := Data{}
 	json.LoadFromPath("data.json", &data)
@@ -136,6 +127,6 @@ func main() {
 		})
 	}
 
-	json.DumpToFile(datalist, "v0.0.0/datalist.json")
+	err := json.DumpToFile(datalist, "v0.0.0/datalist.json")
 	fmt.Println(err)
 }

--- a/cmd/7_add_datalist.go
+++ b/cmd/7_add_datalist.go
@@ -137,6 +137,5 @@ func main() {
 	}
 
 	json.DumpToFile(datalist, "v0.0.0/datalist.json")
-	err = AddSing("v0.0.0/datalist.json", privateKeyBytes)
 	fmt.Println(err)
 }

--- a/cmd/999_uploadOriginData.go
+++ b/cmd/999_uploadOriginData.go
@@ -3,12 +3,22 @@ package main
 import (
 	"fmt"
 	"io"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
 	"log"
 	"time"
 
 	. "github.com/takoyaki-3/butter/cmd/helper"
 	json "github.com/takoyaki-3/go-json"
 	gos3 "github.com/takoyaki-3/go-s3"
+
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 type OriginalData struct {
@@ -18,7 +28,102 @@ type OriginalDataItem struct {
 	Key string `json:"key"`
 }
 
+
+
+func VerifySignature(originalFilePath, signatureFilePath, publicKeyPath string) bool {
+	// 公開鍵の読み込み
+	publicKeyBytes, err := ioutil.ReadFile(publicKeyPath)
+	if err != nil {
+		log.Fatalf("Failed to load public key: %v", err)
+		return false
+	}
+
+	// PEMデコード
+	block, _ := pem.Decode(publicKeyBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		log.Fatalf("Failed to decode PEM block containing public key")
+		return false
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		log.Fatalf("Failed to parse public key: %v", err)
+		return false
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		log.Fatalf("Not an RSA public key")
+		return false
+	}
+
+	// 元のファイルのハッシュの計算
+	originalData, err := ioutil.ReadFile(originalFilePath)
+	if err != nil {
+		log.Fatalf("Failed to read original file: %v", err)
+		return false
+	}
+	hashed := sha256.Sum256(originalData)
+
+	// 署名の読み込み
+	signature, err := ioutil.ReadFile(signatureFilePath)
+	if err != nil {
+		log.Fatalf("Failed to read signature file: %v", err)
+		return false
+	}
+
+	// 署名の検証
+	err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hashed[:], signature)
+	if err != nil {
+		log.Printf("Signature verification failed: %v", err)
+		return false
+	}
+
+	return true
+}
+
+func CheckAllSignaturesInDir(directory, publicKeyPath string) error {
+	return filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// ディレクトリと.sig拡張子のファイルはスキップ
+		if info.IsDir() || strings.HasSuffix(path, ".sig") {
+			return nil
+		}
+
+		signaturePath := path + ".sig"
+		if _, err := os.Stat(signaturePath); os.IsNotExist(err) {
+			return fmt.Errorf("signature file not found for %s", path)
+		}
+
+		// 署名を検証
+		if !VerifySignature(path, signaturePath, publicKeyPath) {
+			return fmt.Errorf("signature verification failed for %s", path)
+		}
+
+		return nil
+	})
+}
+
+func checkData()error{
+	directory := "./v0.0.0"
+	publicKeyPath := "./public_Key.pem" // 公開鍵ファイルのパス
+
+	if err := CheckAllSignaturesInDir(directory, publicKeyPath); err != nil {
+		fmt.Println("Error:", err)
+	}
+	return nil
+}
+
 func main() {
+
+	if err:=checkData();err!=nil{
+		log.Fatalln(err)
+		return
+	}
+
 	sourceDir := "./v0.0.0/"
 	now := time.Now().Format("20060102-150405")
 	targetFile := now + ".tar"

--- a/cmd/9_addSign.go
+++ b/cmd/9_addSign.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/takoyaki-3/butter/cmd/helper"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func SignAllFilesInDir(directory string, privateKeyPath string) error {
+	privateKeyData, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		return err
+	}
+
+	return filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// ディレクトリはスキップ
+		if info.IsDir() {
+			return nil
+		}
+
+		// ファイルの拡張子が.sigの場合は署名をスキップ
+		if filepath.Ext(path) == ".sig" {
+			return nil
+		}
+
+		// ファイルに署名を付与
+		return helper.AddSing(path, privateKeyData)
+	})
+}
+
+func main() {
+	err := SignAllFilesInDir("./v0.0.0/", "key.pem")
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/cmd/cmd.sh
+++ b/cmd/cmd.sh
@@ -8,5 +8,6 @@ go run 5_split.go #
 go run 6_add_gtfs_id_info.go #
 go run 7_add_datalist.go #
 python 8_add_stopdata.py #
+go run 9_addSign.go #
 go run 999_uploadOriginData.go #
 #


### PR DESCRIPTION
これまでは.tarファイルに関しては、.tarファイル内に電子署名を含んでいたが、.tar爆弾を防ぐため、.tarファイルそのものに電子署名を付与する仕様に変更した。併せて、電子署名を付与する箇所を一か所に統一した。

コードさらっと読んで、マージして頂ければ幸いです！
（本当は動作確認まですべきなのだけど、まぁ、そこまでやるのも大変だと思うので）